### PR TITLE
Support wrappers as google.protobuf.*Value

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,36 @@ type SampleMessage = Readonly<{
 NestedType other than map is not supported.
 Define message without nesting it.
 
+### Wrappers
+
+```proto
+message SampleMessage {
+  google.protobuf.DoubleValue double_value = 1;
+  google.protobuf.FloatValue float_value = 2;
+  google.protobuf.Int32Value int32_value = 3;
+  google.protobuf.Int64Value int64_value = 4;
+  google.protobuf.Uint32Value uint32_value = 5;
+  google.protobuf.Uint64Value uint64_value = 6;
+  google.protobuf.BoolValue bool_value = 7;
+  google.protobuf.BytesValue bytes_value = 8;
+  google.protobuf.StringValue string_value = 9;
+}
+```
+
+```typescript
+type SampleMessage = Readonly<{
+  doubleValue: number | undefined;
+  floatValue: number | undefined;
+  int32Value: number | undefined;
+  int64Value: number | undefined;
+  uint32Value: number | undefined;
+  uint64Value: number | undefined;
+  boolValue: boolean | undefined;
+  bytesValue: string | undefined;
+  stringValue: string | undefined;
+}>;
+```
+
 ## License
 
 [MIT License](https://opensource.org/licenses/MIT).

--- a/main.go
+++ b/main.go
@@ -38,6 +38,20 @@ func processReq(req *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResp
 			fieldsOrder := []string{}
 			nestedTypes := make(map[string]string)
 			messageTypeName := messageType.GetName()
+
+			switch messageTypeName {
+			case "DoubleValue",
+				"FloatValue",
+				"Int32Value",
+				"Int64Value",
+				"UInt32Value",
+				"UInt64Value",
+				"BoolValue",
+				"BytesValue",
+				"StringValue":
+				continue
+			}
+
 			oneofTypes := []map[string]string{}
 			oneofTypesOrder := [][]string{}
 			for range messageType.GetOneofDecl() {
@@ -155,6 +169,15 @@ func convertType(field *descriptorpb.FieldDescriptorProto, nestedTypes map[strin
 		descriptorpb.FieldDescriptorProto_TYPE_MESSAGE:
 		ns := strings.Split(field.GetTypeName(), ".")
 		tsType = ns[len(ns)-1]
+
+		switch tsType {
+		case "DoubleValue", "FloatValue", "Int32Value", "Int64Value", "UInt32Value", "UInt64Value":
+			tsType = "number | undefined"
+		case "BoolValue":
+			tsType = "boolean | undefined"
+		case "BytesValue", "StringValue":
+			tsType = "string | undefined"
+		}
 	default:
 		tsType = "unknown"
 	}


### PR DESCRIPTION
Do not define your own message like `DoubleValue`.